### PR TITLE
Adds a Shortcut for using HEX inside of rgba()

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postcss-import": "^8.1.0",
     "postcss-mixins": "^4.0.1",
     "postcss-nested": "^1.0.0",
+    "postcss-hexrgba": "^1.0.0",
     "request": "^2.7",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.5",

--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -7,6 +7,7 @@ module.exports = function( gulp ) {
 	var cssimport   = require( 'postcss-import' );
 	var cssnested   = require( 'postcss-nested' );
 	var cssmixins   = require( 'postcss-mixins' );
+	var csshexrgba  = require( 'postcss-hexrgba' );
 	var cssmqpacker = require( 'css-mqpacker' );
 	var rename      = require( 'gulp-rename' );
 
@@ -16,7 +17,8 @@ module.exports = function( gulp ) {
 			cssmixins(),
 			cssnested(),
 			cssnext(),
-			cssmqpacker()
+			cssmqpacker(),
+			csshexrgba()
 		];
 
 		var banner = [


### PR DESCRIPTION
Adds https://github.com/seaneking/postcss-hexrgba into our PostCSS stack.

Allowing:
```
.bar {
  color: rgba(#0fab53, 0.8)
}

.foo {
  color: rgba(--foo-color, 0.8)
}
```