### PR TITLE
Fixing bug with multi-stage ref handling

### DIFF
--- a/scripts/fetchPackageJSON.js
+++ b/scripts/fetchPackageJSON.js
@@ -11,9 +11,8 @@ if ( fs.existsSync( process.cwd() + '/common' ) ) {
 	// If Common is not a branch, it will required a second command
 	if ( 'HEAD' === ref ) {
 		ref = spawnSync( 'git', [ 'rev-parse', '--verify', 'HEAD' ], { shell: true, cwd: process.cwd() + '/common' } );
+		ref = ref.stdout.toString().trim();
 	}
-
-	ref = ref.stdout.toString().trim();
 } else {
 	ref = spawnSync( 'git', [ 'rev-parse', '--abbrev-ref', 'HEAD' ], { shell: true, cwd: process.cwd() } );
 	ref = ref.stdout.toString().trim();


### PR DESCRIPTION
When ref.stdout != HEAD, the second attempt at grabbing ref.stdout errored out.

Here's the error:

![Screen Shot 2019-07-05 at 10 48 07 AM](https://user-images.githubusercontent.com/430385/60730129-69840c00-9f12-11e9-90d7-f5736c378d8f.png)

Here's what happens after the fix:

![Screen Shot 2019-07-05 at 10 48 47 AM](https://user-images.githubusercontent.com/430385/60730164-7bfe4580-9f12-11e9-9c68-0e0d258feb50.png)
