### PR TITLE
PDTOOLS-86: Use "package-safelist" instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,12 @@ gulp pull --branch <branch-you-want-to-pull>
 
 #### zip
 
-This task packages the files indicated by `package-whitelist.json` into
+This task packages the files indicated by `package-safelist.json` into
 a zip file that it places one directory above the plugin's base
 directory.
+
+**Note:**  `package-whitelist` has been deprecated if you have one please rename it to `pacakge-safelist`.
+
 
 ```
 gulp zip

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This task packages the files indicated by `package-safelist.json` into
 a zip file that it places one directory above the plugin's base
 directory.
 
-**Note:**  `package-whitelist` has been deprecated if you have one please rename it to `package-safelist`.
+**Note:**  `package-whitelist.json` has been deprecated if you have one please rename it to `package-safelist.json`.
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This task packages the files indicated by `package-safelist.json` into
 a zip file that it places one directory above the plugin's base
 directory.
 
-**Note:**  `package-whitelist` has been deprecated if you have one please rename it to `pacakge-safelist`.
+**Note:**  `package-whitelist` has been deprecated if you have one please rename it to `package-safelist`.
 
 
 ```

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -13,7 +13,7 @@ module.exports = function( gulp ) {
 		let packageSafeListContents;
 
 		try {
-			if ( fs.existsSync( './package-safelist.json' ) ) {
+			if ( fs.accessSync( './package-safelist.json', fs.constants.F_OK ) ) {
 				packageSafeListContents = fs.readFileSync( './package-safelist.json', 'utf8' )
 			} else {
 				packageSafeListContents = fs.readFileSync( './package-whitelist.json', 'utf8' )
@@ -28,7 +28,7 @@ module.exports = function( gulp ) {
 		let commonZipContents;
 
 		try {
-			if ( fs.existsSync( './common/package-safelist.json' ) ) {
+			if ( fs.accessSync( './common/package-safelist.json', fs.constants.F_OK ) ) {
 				commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );
 			} else if ( fs.existsSync( './common/package-whitelist.json' ) ) {{
 				commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -24,7 +24,7 @@ module.exports = function( gulp ) {
 		}
 
 		let json = parseJson( packageContents );
-		let zipInclude = parseJson( packageSafeListContents );
+		let zipInclude = parseJson( packageSafelistContents );
 		let commonZipContents;
 
 		try {

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -34,7 +34,7 @@ module.exports = function( gulp ) {
 				commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );
 			}
 		} catch( e ) {
-			// We didnt havekcommon we avoid failing
+			// We didnt have common we avoid failing
 		}
 
 		let commonZipInclude = [];

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -29,7 +29,7 @@ module.exports = function( gulp ) {
 
 		try {
 			if ( fs.accessSync( './common/package-safelist.json', fs.constants.F_OK ) ) {
-				commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );
+				commonZipContents = fs.readFileSync( './common/package-safelist.json', 'utf8' );
 			} else if ( fs.existsSync( './common/package-whitelist.json' ) ) {{
 				commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );
 			}

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -10,13 +10,13 @@ module.exports = function( gulp ) {
 	// this task copies files we'll zip into a build directory
 	gulp.task( 'zip-copy-files', function() {
 		let packageContents = fs.readFileSync( './package.json', 'utf8' );
-		let packageSafeListContents;
+		let packageSafelistContents;
 
 		try {
 			if ( fs.accessSync( './package-safelist.json', fs.constants.F_OK ) ) {
-				packageSafeListContents = fs.readFileSync( './package-safelist.json', 'utf8' )
+				packageSafelistContents = fs.readFileSync( './package-safelist.json', 'utf8' )
 			} else {
-				packageSafeListContents = fs.readFileSync( './package-whitelist.json', 'utf8' )
+				packageSafelistContents = fs.readFileSync( './package-whitelist.json', 'utf8' )
 			}
 
 		} catch( e ) {

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -10,15 +10,31 @@ module.exports = function( gulp ) {
 	// this task copies files we'll zip into a build directory
 	gulp.task( 'zip-copy-files', function() {
 		let packageContents = fs.readFileSync( './package.json', 'utf8' );
-		let packageWhitelistContents = fs.readFileSync( './package-whitelist.json', 'utf8' )
+		let packageSafeListContents;
+
+		try {
+			if ( fs.existsSync( './package-safelist.json' ) ) {
+				packageSafeListContents = fs.readFileSync( './package-safelist.json', 'utf8' )
+			} else {
+				packageSafeListContents = fs.readFileSync( './package-whitelist.json', 'utf8' )
+			}
+
+		} catch( e ) {
+			console.log( e );
+		}
+
 		let json = parseJson( packageContents );
-		let zipInclude = parseJson( packageWhitelistContents );
+		let zipInclude = parseJson( packageSafeListContents );
 		let commonZipContents;
 
 		try {
-			commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );
+			if ( fs.existsSync( './common/package-safelist.json' ) ) {
+				commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );
+			} else if ( fs.existsSync( './common/package-whitelist.json' ) ) {{
+				commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );
+			}
 		} catch( e ) {
-			// We didnt have common we avoid failing
+			// We didnt havekcommon we avoid failing
 		}
 
 		let commonZipInclude = [];

--- a/util/zip.js
+++ b/util/zip.js
@@ -2,7 +2,17 @@ var fs = require('fs');
 var archiver = require('archiver');
 
 const json          = JSON.parse( fs.readFileSync( 'package.json' ) );
-const zip_whitelist = JSON.parse( fs.readFileSync( 'package-whitelist.json' ) );
+let zip_safelist;
+
+try {
+	if ( fs.accessSync( 'package-safelist.json', fs.constants.F_OK ) ) {
+		zip_safelist = JSON.parse( fs.readFileSync( 'package-safelist.json' ) );
+	} else {
+		zip_safelist = JSON.parse( fs.readFileSync( 'package-whitelist.json' ) );
+	}
+} catch ( e ) {
+	console.log( e );
+}
 
 // create a file to stream archive data to.
 var output = fs.createWriteStream( __dirname + '/../../' + json._zipname + '.' + json.version + '.zip' );
@@ -21,7 +31,7 @@ archive.on( 'error', function(err) {
 
 archive.pipe(output);
 
-zip_whitelist.forEach( function( file ) {
+zip_safelist.forEach( function( file ) {
 	if ( '/' === file.slice( -1 ) ) {
 		archive.directory( file, file );
 		return;

--- a/util/zip.js
+++ b/util/zip.js
@@ -2,13 +2,13 @@ var fs = require('fs');
 var archiver = require('archiver');
 
 const json          = JSON.parse( fs.readFileSync( 'package.json' ) );
-let zip_safelist;
+let zipSafelist;
 
 try {
 	if ( fs.accessSync( 'package-safelist.json', fs.constants.F_OK ) ) {
-		zip_safelist = JSON.parse( fs.readFileSync( 'package-safelist.json' ) );
+		zipSafelist = JSON.parse( fs.readFileSync( 'package-safelist.json' ) );
 	} else {
-		zip_safelist = JSON.parse( fs.readFileSync( 'package-whitelist.json' ) );
+		zipSafelist = JSON.parse( fs.readFileSync( 'package-whitelist.json' ) );
 	}
 } catch ( e ) {
 	console.log( e );
@@ -31,7 +31,7 @@ archive.on( 'error', function(err) {
 
 archive.pipe(output);
 
-zip_safelist.forEach( function( file ) {
+zipSafelist.forEach( function( file ) {
 	if ( '/' === file.slice( -1 ) ) {
 		archive.directory( file, file );
 		return;


### PR DESCRIPTION
Add the option to use 'package-safelist` instead on the plugins side of
things in order to set a series of allowed packages or files to be keep
on the ZIP.

Additionally this also allows to support the old files in order to be
backward compatible.

Ticket: [PDTOOLS-86]

[PDTOOLS-86]: https://moderntribe.atlassian.net/browse/PDTOOLS-86