### PR TITLE
fix syntax error

### DIFF
--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -30,7 +30,7 @@ module.exports = function( gulp ) {
 		try {
 			if ( fs.accessSync( './common/package-safelist.json', fs.constants.F_OK ) ) {
 				commonZipContents = fs.readFileSync( './common/package-safelist.json', 'utf8' );
-			} else if ( fs.existsSync( './common/package-whitelist.json' ) ) {{
+			} else if ( fs.existsSync( './common/package-whitelist.json' ) ) {
 				commonZipContents = fs.readFileSync( './common/package-whitelist.json', 'utf8' );
 			}
 		} catch( e ) {


### PR DESCRIPTION
**Ticket:** N/A

This fixes a syntax error that would occur when trying to build assets.

**Screenshot:**

Before:
![image](https://user-images.githubusercontent.com/16699941/92145966-97811b00-ee4b-11ea-921c-42af39c4ae13.png)

After:
![image](https://user-images.githubusercontent.com/16699941/92145996-a071ec80-ee4b-11ea-8881-cc49213c9f56.png)
