### PR TITLE
Task/handle gulp v3 and v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,14 @@ module.exports = function( gulp ) {
 	var normalizedPath = require( 'path' ).join( __dirname, 'tasks' );
 
 	require( 'fs' ).readdirSync( normalizedPath ).forEach( function( file ) {
+		if ( 'default.js' === file || 'package.js' === file ) {
+			return;
+		}
+
 		require( './tasks/' + file )( gulp );
 	} );
+
+	// Gulp v4 must have tasks that are used in series() or parallel() defined first.
+	require( './tasks/default.js' )( gulp );
+	require( './tasks/package.js' )( gulp );
 };

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -1,17 +1,32 @@
 module.exports = function( gulp ) {
 	'use strict';
 
-	var sequence = require( 'run-sequence' ).use( gulp );
+	var task;
 
-	var task = function( cb ) {
-		sequence(
+	// Gulp is v3.
+	if ( gulp.hasTask ) {
+		var sequence = require( 'run-sequence' ).use( gulp );
+		task = function( cb ) {
+			sequence(
+				'postcss',
+				[
+					'compress-css',
+					'compress-js'
+				],
+				cb
+			);
+		};
+
+	// Gulp is v4.
+	} else {
+		task = gulp.series(
 			'postcss',
-			[
+			gulp.parallel(
 				'compress-css',
-				'compress-js'
-			],
-			cb
+				'compress-js',
+			),
 		);
-	};
+	}
+
 	gulp.task( 'default', task );
 };

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -1,7 +1,11 @@
 module.exports = function( gulp ) {
 	'use strict';
 
-	var sequence = require( 'run-sequence' ).use( gulp ),
+	var task;
+
+	// Gulp is v3.
+	if ( gulp.hasTask ) {
+		var sequence = require( 'run-sequence' ).use( gulp );
 		task = function( callback ) {
 			sequence(
 				'pull',
@@ -15,6 +19,20 @@ module.exports = function( gulp ) {
 				callback
 			);
 		};
+
+	// Gulp is v4.
+	} else {
+		task = gulp.series(
+			'pull',
+			'postcss',
+			gulp.parallel(
+				'compress-js',
+				'compress-css',
+			),
+			'webpack',
+			'zip',
+		);
+	}
 
 	gulp.task( 'package', task );
 };

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -84,14 +84,27 @@ module.exports = function( gulp ) {
 		cb();
 	} );
 
-	let task = function( cb ) {
-		sequence(
+	var task;
+
+	// Gulp is v3.
+	if ( gulp.hasTask ) {
+		task = function( cb ) {
+			sequence(
+				'zip-copy-files',
+				'zip-do-zip',
+				'zip-purge-build-dir',
+				cb
+			);
+		};
+
+	// Gulp is v4.
+	} else {
+		task = gulp.series(
 			'zip-copy-files',
 			'zip-do-zip',
 			'zip-purge-build-dir',
-			cb
 		);
-	};
+	}
 
 	gulp.task( 'zip', task );
 };


### PR DESCRIPTION
**Ticket:** N/A

This PR allows us to use both v3 and v4 of Gulp. Gulp v4 is not compatible with `run-sequence`, so we need to detect for the `gulp.hasTask()` method which is only available in v3 and use `run-sequence`. This will allow us to update Gulp to v4 plugin by plugin without breaking any of the existing functionality. See: https://docs.google.com/document/d/1YlVNc2XYiTZYkASvm99NNViUjcU-Mkrz6V36xJJjNvk/edit#

**Artifact:**

Using Gulp v4

![image](https://user-images.githubusercontent.com/16699941/96840186-b596ef00-147c-11eb-975a-07d4fc4d50db.png)

Running gulp build

![image](https://user-images.githubusercontent.com/16699941/96840292-d3645400-147c-11eb-90ab-4e23fe48cacf.png)
