### PR TITLE
Add the block-editor package dependency

### DIFF
--- a/webpack/externals/wp.js
+++ b/webpack/externals/wp.js
@@ -1,4 +1,5 @@
 const wp = [
+	'block-editor',
 	'blocks',
 	'components',
 	'date',


### PR DESCRIPTION
This allows for `import { InspectorControls } from '@wordpress/block-editor';` usage in projects.